### PR TITLE
Avoid world-writable device nodes

### DIFF
--- a/release/linux/trezor.rules
+++ b/release/linux/trezor.rules
@@ -2,7 +2,7 @@
 # http://bitcointrezor.com/
 
 # TREZOR
-SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE:="0666", GROUP="dialout", SYMLINK+="trezor%n"
+SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
 
 # TREZOR Raspberry Pi Shield
-SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea80", MODE:="0666", GROUP="dialout", SYMLINK+="trezor%n"
+SUBSYSTEM=="usb", ATTR{idVendor}=="10c4", ATTR{idProduct}=="ea80", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"


### PR DESCRIPTION
Tag the devices uaccess so that they're marked writable by the local active
session users only. The udev-acl tag is for old Ubuntu compatibility.
