### PR TITLE
Compatibility with gcc ver<4.9.0 (reference data member initialization)

### DIFF
--- a/src/http_server.hpp
+++ b/src/http_server.hpp
@@ -175,7 +175,7 @@ struct server
     cors_validator validator;
 
     server(route_table const &table, cors_validator cors)
-        : routes{table},
+        : routes(table),
           validator{cors}
     { }
 


### PR DESCRIPTION
  GCC prior to 4.9.0 created a temporary when a reference was initialized
  from brace-initializer. That means that if a reference data member was
  initialized in a constructor with brace-initializer syntax, the referred
  object will be destroyed upon the exit from constructor and reference would be
  invalid.
  This behaviour was changed in 2012 standard's update (DR1288). GCC adopted this
  change in revision 4.9.0.
  So, to keep compatibility with GCC prior to 4.9.0, better to avoid brace-initialization
  of reference data members.
