### PR TITLE
Patch to build on ARM: accept dynamic boost libs and add glibc symvers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,16 +58,15 @@ target_link_libraries(trezord ${OS_LIBRARIES})
 # add dynamic libs
 find_package(CURL REQUIRED)
 find_package(libmicrohttpd REQUIRED)
+find_package(Boost 1.53.0 REQUIRED
+  regex thread system unit_test_framework program_options chrono)
 
 # add static libs
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   set(BUILD_SHARED_LIBS off)
-  set(Boost_USE_STATIC_LIBS on)
   set(CMAKE_FIND_STATIC FIRST)
 endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-find_package(Boost 1.53.0 REQUIRED
-  regex thread system unit_test_framework program_options chrono)
 find_package(Protobuf 2.5.0 REQUIRED)
 find_package(jsoncpp REQUIRED)
 

--- a/src/glibc_compat.c
+++ b/src/glibc_compat.c
@@ -1,7 +1,9 @@
 #include <stddef.h>
 
-#ifdef __amd64__
+#if defined(__amd64__)
    #define GLIBC_COMPAT_SYMBOL(X) __asm__(".symver __" #X "_compat," #X "@GLIBC_2.2.5");
+#elif defined(__arm__)
+   #define GLIBC_COMPAT_SYMBOL(X) __asm__(".symver __" #X "_compat," #X "@GLIBC_2.4");
 #else
    #define GLIBC_COMPAT_SYMBOL(X) __asm__(".symver __" #X "_compat," #X "@GLIBC_2.0");
 #endif


### PR DESCRIPTION
Hi, this is what I had to do to build trezord on ARM (Arch Linux on ARM):
- accept dynamic boost libs instead of forcing static ones
- add arch-specific symvers directives for glibc symbols to glibc_compat.c
- build protobuf 2.5 from source with --disabled-shared by modifying the PKGBUILD from v2.6 in the straighforward way (the current protobuf in ALARM repo is v2.6 and contains only dynamic libraries)

Some details in commit messages. The built binary works well (tested in Firefox 38.0.5).

(Perhaps these patches are not right or not safe, but at least the info might save the next person some time.)

Btw, thank you for maintaining a standalone daemon in addition to whatever browser extensions (Chrome is not smooth saling on every architecture).
